### PR TITLE
Memory violation fix

### DIFF
--- a/cmd/genbindings/emitcabi.go
+++ b/cmd/genbindings/emitcabi.go
@@ -1270,7 +1270,7 @@ static constexpr std::size_t seaqt_aligned_sizeof() {
 				// Allocate memory for the type and requested user data avoiding variable
 				// name
 				ret.WriteString(
-					"\tvoid* _mem_ = malloc(seaqt_aligned_sizeof<" + derivedName + ">());\n" +
+					"\tvoid* _mem_ = malloc(seaqt_aligned_sizeof<" + derivedName + ">() + vdata);\n" +
 						"\treturn _mem_ ? new (_mem_)" + derivedName + "(" + forwarding + ") : nullptr;\n",
 				)
 			} else {


### PR DESCRIPTION
Memory was allocated only for the c++ object, with no additional space requested by the caller.