### PR TITLE
Wrap commandLineParams call in try/catch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ genbindings: $(BUILDSTAMPS)
 
 copy-libseaqt: genbindings
 	cd gen/ ;\
-	for a in *seaqt-*; do cp -ar ../libseaqt/* $$a; done ;\
-	for a in *seaqt-5.15; do cp -ar ../libseaqt-5.15/* $$a; done ;\
-	for a in *seaqt-6.4; do echo $a; cp -ar ../libseaqt-6.4/* $$a; done ;
+	for a in *seaqt-*; do cp -aR ../libseaqt/* $$a; done ;\
+	for a in *seaqt-5.15; do cp -aR ../libseaqt-5.15/* $$a; done ;\
+	for a in *seaqt-6.4; do echo $a; cp -aR ../libseaqt-6.4/* $$a; done ;
 
 gencommits: copy-libseaqt
 	cd gen/ ;\

--- a/cmd/genbindings/emitnim.go
+++ b/cmd/genbindings/emitnim.go
@@ -523,7 +523,18 @@ func (gfs *nimFileState) emitParametersNim2CABIForwarding(m CppMethod, extra str
 
 			preamble += gfs.ind + "# Convert []string to long-lived int& argc, char** argv, never call free()\n"
 			preamble += gfs.ind + "var args2 = @[getAppFilename()]\n"
+			preamble += gfs.ind + "try:\n"
+
+			gfs.indent()
 			preamble += gfs.ind + "args2.add commandLineParams()\n"
+
+			gfs.dedent()
+			preamble += gfs.ind + "except OSError:\n"
+
+			gfs.indent()
+			preamble += gfs.ind + "echo getCurrentExceptionMsg()\n"
+
+			gfs.dedent()
 			preamble += gfs.ind + "var argv: cStringArray = allocCstringArray(args2)\n"
 			preamble += gfs.ind + "var argc {.threadvar.}: cint\n"
 			preamble += gfs.ind + "argc = args2.len.cint\n"


### PR DESCRIPTION
Fixing the Android build by wrapping commandLineParams call in try/catch

Extra:
[fix: copy-libseaqt makefile target fails on MacOs](https://github.com/seaqt/seaqt-gen/commit/a5837ddaf85b0e61ebd1013c328d307d0a21c9f2)